### PR TITLE
log time of predication scheduling

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -295,6 +295,7 @@ func computeExpansionOption(context *context.AutoscalingContext, podEquivalenceG
 			option.Pods = append(option.Pods, eg.pods...)
 			// mark pod group as (theoretically) schedulable
 			eg.schedulable = true
+			klog.V(2).Infof("Pod %s can be scheduled on %s", samplePod.Name, nodeGroup.Id())
 		} else {
 			klog.V(2).Infof("Pod %s can't be scheduled on %s, predicate checking error: %v", samplePod.Name, nodeGroup.Id(), err.VerboseMessage())
 			if podCount := len(eg.pods); podCount > 1 {


### PR DESCRIPTION
https://www.notion.so/Spaas-ads-instances-scaling-out-slow-abfe7bf9cbcf40f09f25537302aa10a0

we need to know why CA was stuck