### PR TITLE
[workaround] add owner for spark jobs

### DIFF
--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	pod_util "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 )
@@ -233,7 +234,11 @@ func GetPodsForDeletionOnNodeDrain(
 
 // ControllerRef returns the OwnerReference to pod's controller.
 func ControllerRef(pod *apiv1.Pod) *metav1.OwnerReference {
-	return metav1.GetControllerOf(pod)
+	cp := metav1.GetControllerOf(pod)
+	if pod.Labels["jobType"] == "spark" && pod.Labels["attemptId"] != "" {
+		cp.UID = types.UID{pod.Labels["attemptId"]}
+	}
+	return cp
 }
 
 // isPodTerminal checks whether the pod is in a terminal state.


### PR DESCRIPTION
CA is using [ownerReference](https://sourcegraph.smartnews.net/github.com/smartnews/k8s-autoscaler@cluster-autoscaler-release-1.25/-/blob/cluster-autoscaler/core/equivalence_groups.go#L65) to group pods,

in case of Spark pods, the owner UID are different even if they are from the same job, but they all have the same `attemptId`. 

```  
  labels:
    attemptId: ya8845258bbb74d1dbed06cd1b283c9cb
    jobType: spark
    podType: executor
  ownerReferences:
    - apiVersion: v1
      kind: Pod
      uid: ef0abbad-28f2-401b-8227-e70f0c1c6ce5
      controller: true
```