### PR TITLE
bypass volumebinder filter check for scylla pod and scylla node

### DIFF
--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -126,7 +126,10 @@ func (p *SchedulerBasedPredicateChecker) FitsAnyNodeMatching(clusterSnapshot Clu
 
 		filterStatuses := p.framework.RunFilterPlugins(context.TODO(), state, pod, nodeInfo)
 		ok := true
-		for _, filterStatus := range filterStatuses {
+		for filterName, filterStatus := range filterStatuses {
+			if p.bypassFilterPlugin(pod, nodeInfo, filterName, "VolumeBinding", isNodeForScyllaPod) {
+				continue
+			}
 			if !filterStatus.IsSuccess() {
 				ok = false
 				break
@@ -167,6 +170,10 @@ func (p *SchedulerBasedPredicateChecker) CheckPredicates(clusterSnapshot Cluster
 
 	filterStatuses := p.framework.RunFilterPlugins(context.TODO(), state, pod, nodeInfo)
 	for filterName, filterStatus := range filterStatuses {
+		if p.bypassFilterPlugin(pod, nodeInfo, filterName, "VolumeBinding", isNodeForScyllaPod) {
+			continue
+		}
+
 		if !filterStatus.IsSuccess() {
 			if filterStatus.IsUnschedulable() {
 				return NewPredicateError(
@@ -198,3 +205,31 @@ func (p *SchedulerBasedPredicateChecker) buildDebugInfo(filterName string, nodeI
 		return emptyString
 	}
 }
+
+func (p *SchedulerBasedPredicateChecker) bypassFilterPlugin(
+	pod *apiv1.Pod,
+	nodeInfo *schedulerframework.NodeInfo,
+	curFilterName string,
+	bypassFilterName string,
+	check func(*apiv1.Pod, *schedulerframework.NodeInfo) bool) bool {
+
+	// this is not the filter we want to bypass
+	if curFilterName != bypassFilterName {
+		return false
+	}
+
+	return check(pod, nodeInfo)
+}
+
+func isNodeForScyllaPod(pod *apiv1.Pod, nodeInfo *schedulerframework.NodeInfo) bool {
+	if pod.Labels["app"] == "scylla" && nodeInfo.Node().Labels["purpose"] == "scylla" {
+		nodeSelectorTerm := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+		for _, matchExpression := range nodeSelectorTerm.MatchExpressions {
+			if matchExpression.Key == "nodegroup" && matchExpression.Values[0] == nodeInfo.Node().Labels["nodegroup"] {
+				return true
+			}
+		}
+	}
+	return false
+}
+


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
